### PR TITLE
Auth API update and optional token caching

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -3,6 +3,7 @@
 USERNAME = <myq username>
 PASSWORD = <myq password>
 BRAND = Chamberlain
+TOKENTTL = 60
 
 [ISYConfiguration]
 # Set USE_ISY = False if you don't wish to use the ISY features


### PR DESCRIPTION
Got it working with the most recent API change, also added optional token caching to mimic the real app, new config.ini variable (TOKENTTL) controls the caching, if set to 0 - caching is disabled (backwards compatibility), otherwise token is deemed "valid" for the amount of minutes configured. That would lower the amount of authentication requests if updates are pulled frequently.